### PR TITLE
Fixed 44 issues of type: PYTHON_F401 throughout 44 files in repo.

### DIFF
--- a/amplpy/__init__.py
+++ b/amplpy/__init__.py
@@ -1,18 +1,3 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-from .outputhandler import OutputHandler, Kind
-from .errorhandler import ErrorHandler
-from .exceptions import AMPLException
-from .iterators import EntityMap
-from .runnable import Runnable
-from .objective import Objective
-from .variable import Variable
-from .constraint import Constraint
-from .set import Set
-from .parameter import Parameter
-from .entity import Entity
-from .dataframe import DataFrame
-from .utils import multidict, register_magics
-from .environment import Environment
-from .ampl import AMPL
 __version__ = '0.6.5'

--- a/amplpy/ampl.py
+++ b/amplpy/ampl.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import map, object
 from past.builtins import basestring
 
 from threading import Thread, Lock

--- a/amplpy/amplpython/__init__.py
+++ b/amplpy/amplpython/__init__.py
@@ -18,5 +18,3 @@ if platform.system() == 'Windows':
     except:
         pass
 
-from .amplpython import *
-from .amplpython import _READTABLE, _WRITETABLE

--- a/amplpy/base.py
+++ b/amplpy/base.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
+from builtins import object
 
 
 class BaseClass(object):

--- a/amplpy/constraint.py
+++ b/amplpy/constraint.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
 from .entity import Entity
 

--- a/amplpy/dataframe.py
+++ b/amplpy/dataframe.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import map, range, zip
 from past.builtins import basestring
 from numbers import Real
 

--- a/amplpy/entity.py
+++ b/amplpy/entity.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import map
 from past.builtins import basestring
 
 from .base import BaseClass

--- a/amplpy/environment.py
+++ b/amplpy/environment.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
 from .iterators import EnvIterator
 from .base import BaseClass

--- a/amplpy/errorhandler.py
+++ b/amplpy/errorhandler.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
-from . import amplpython
 
 
 class ErrorHandler:

--- a/amplpy/exceptions.py
+++ b/amplpy/exceptions.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
-from . import amplpython
 
 
 class AMPLException(Exception):

--- a/amplpy/iterators.py
+++ b/amplpy/iterators.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import object
 from past.builtins import basestring
 
 from .utils import Utils, Tuple

--- a/amplpy/objective.py
+++ b/amplpy/objective.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
 from .entity import Entity
 

--- a/amplpy/outputhandler.py
+++ b/amplpy/outputhandler.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
+from builtins import object
 
 from . import amplpython
 

--- a/amplpy/parameter.py
+++ b/amplpy/parameter.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import map, zip
 from past.builtins import basestring
 from numbers import Real
 

--- a/amplpy/runnable.py
+++ b/amplpy/runnable.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
 from . import amplpython
 
@@ -18,4 +16,3 @@ class Runnable(amplpython.Runnable):
         """
         Function called when the execution of the async operation is finished.
         """
-        pass

--- a/amplpy/set.py
+++ b/amplpy/set.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import map
 from past.builtins import basestring
 from numbers import Real
 

--- a/amplpy/tests/TestBase.py
+++ b/amplpy/tests/TestBase.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 
 from .context import amplpy
 import unittest

--- a/amplpy/tests/__main__.py
+++ b/amplpy/tests/__main__.py
@@ -3,12 +3,6 @@
 from __future__ import absolute_import
 
 import unittest
-from .test_ampl import TestAMPL
-from .test_entities import TestEntities
-from .test_iterators import TestIterators
-from .test_dataframe import TestDataFrame
-from .test_environment import TestEnvironment
-from .test_properties import TestProperties
 
 
 if __name__ == '__main__':

--- a/amplpy/tests/context.py
+++ b/amplpy/tests/context.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-import sys
-import os
 
-import amplpy

--- a/amplpy/tests/test_ampl.py
+++ b/amplpy/tests/test_ampl.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 from past.builtins import basestring
 
 from . import TestBase
@@ -83,7 +82,6 @@ class TestAMPL(TestBase.TestBase):
         self.assertEqual(ampl.getOption('d'), True)
 
     def testHandlers(self):
-        from time import sleep
         ampl = self.ampl
 
         class MyOutputHandler(amplpy.OutputHandler):

--- a/amplpy/tests/test_dataframe.py
+++ b/amplpy/tests/test_dataframe.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 
 from . import TestBase
 import unittest
 from amplpy import DataFrame
-import amplpy
 import os
 
 

--- a/amplpy/tests/test_entities.py
+++ b/amplpy/tests/test_entities.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 from past.builtins import basestring
 
 from . import TestBase

--- a/amplpy/tests/test_environment.py
+++ b/amplpy/tests/test_environment.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import sorted
 
 import unittest
-import amplpy
 import os
 
 

--- a/amplpy/tests/test_iterators.py
+++ b/amplpy/tests/test_iterators.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 
 from . import TestBase
 import unittest
-import amplpy
 
 
 class TestIterators(TestBase.TestBase):

--- a/amplpy/tests/test_properties.py
+++ b/amplpy/tests/test_properties.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 
 from . import TestBase
 import unittest
-import amplpy
 
 
 class TestProperties(TestBase.TestBase):

--- a/amplpy/utils.py
+++ b/amplpy/utils.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring, unicode
-from sys import version_info
+from builtins import object, range
+from past.builtins import unicode
 
 from . import amplpython
 from .base import BaseClass

--- a/amplpy/variable.py
+++ b/amplpy/variable.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
-from past.builtins import basestring
 
 from .entity import Entity
 

--- a/docs/build/html/_downloads/1024a990d8a7e3d67cb8c5268efb3f64/multidimensionalexample.py
+++ b/docs/build/html/_downloads/1024a990d8a7e3d67cb8c5268efb3f64/multidimensionalexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/docs/build/html/_downloads/176a91f8cbb9b6614b6f6089cabf98d0/efficientfrontier.py
+++ b/docs/build/html/_downloads/176a91f8cbb9b6614b6f6089cabf98d0/efficientfrontier.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 import sys
 import os
 

--- a/docs/build/html/_downloads/1e860c42938854d6b061aff9d370f07a/dietmodel.py
+++ b/docs/build/html/_downloads/1e860c42938854d6b061aff9d370f07a/dietmodel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/docs/build/html/_downloads/24d37c88d604fbb3666d8eb8ff57ed73/firstexample.py
+++ b/docs/build/html/_downloads/24d37c88d604fbb3666d8eb8ff57ed73/firstexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/docs/build/html/_downloads/2e6695a5e0d79bf096d0f3074b4c4d64/dataframeexample.py
+++ b/docs/build/html/_downloads/2e6695a5e0d79bf096d0f3074b4c4d64/dataframeexample.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 import sys
 import os
 

--- a/docs/build/html/_downloads/bd48f6e96068232724e43361818ac04f/trackingmodel.py
+++ b/docs/build/html/_downloads/bd48f6e96068232724e43361818ac04f/trackingmodel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/docs/build/html/_downloads/d385af6ad6907bc05437ec9ddcf736ce/optionsexample.py
+++ b/docs/build/html/_downloads/d385af6ad6907bc05437ec9ddcf736ce/optionsexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/docs/build/html/_downloads/e908e30808136a03f0d025140fa18368/asyncexample.py
+++ b/docs/build/html/_downloads/e908e30808136a03f0d025140fa18368/asyncexample.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 
 
 def main(argc, argv):
-    from amplpy import AMPL, DataFrame
+    from amplpy import AMPL
     import amplpy
     from time import time
     from threading import Lock

--- a/examples/asyncexample.py
+++ b/examples/asyncexample.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 
 
 def main(argc, argv):
-    from amplpy import AMPL, DataFrame
+    from amplpy import AMPL
     import amplpy
     from time import time
     from threading import Lock

--- a/examples/dataframeexample.py
+++ b/examples/dataframeexample.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 import sys
 import os
 

--- a/examples/dietmodel.py
+++ b/examples/dietmodel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/examples/efficientfrontier.py
+++ b/examples/efficientfrontier.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
+from builtins import range
 import sys
 import os
 

--- a/examples/firstexample.py
+++ b/examples/firstexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/examples/multidimensionalexample.py
+++ b/examples/multidimensionalexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/examples/optionsexample.py
+++ b/examples/optionsexample.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 
 import unittest
-import amplpy
 
 
 class TestExamples(unittest.TestCase):

--- a/examples/trackingmodel.py
+++ b/examples/trackingmodel.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function, absolute_import, division
-from builtins import map, range, object, zip, sorted
 import sys
 import os
 


### PR DESCRIPTION
PYTHON_F401: 'Module imported but unused.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.        

It was fixed with <a href='https://github.com/myint/autoflake'>autoflake</a>.        

This fix is probably safe because the module was not called anywhere.  But if the removed module had global side-effects,        these will be missing and could cause issues.        