### PR TITLE
Skip param assignment when values is an empty dict

### DIFF
--- a/amplpy/parameter.py
+++ b/amplpy/parameter.py
@@ -112,6 +112,8 @@ class Parameter(Entity):
             TypeError: If called on a scalar parameter.
         """
         if isinstance(values, dict):
+            if not values:
+                return
             indices, values = list(zip(*values.items()))
             indices = Utils.toTupleArray(indices)
             if any(isinstance(value, basestring) for value in values):


### PR DESCRIPTION
With the current implementation of `Parameter.setValues()`, you will get an exception when you set empty values to a parameter (e.g., when you unit-test your model on some simple data).

```
        if isinstance(values, dict):
>           indices, values = list(zip(*values.items()))
E           ValueError: not enough values to unpack (expected 2, got 0)
```

This patch help avoid the exception by skipping assignment when the given values are empty.