### PR TITLE
Setup workaround on M1 and Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $ conda install -c conda-forge amplpy
 
 You can build and install the package locally as follows:
 ```
-$ git clone git@github.com:ampl/amplpy.git
+$ git clone https://github.com/ampl/amplpy.git 
 $ cd amplpy
 $ python updatelib.py
 $ python setup.py build

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ import sys
 import os
 
 OSTYPE = platform.system()
-ARCH = platform.processor()
+ARCH = platform.processor() or platform.machine()
 x64 = platform.architecture()[0] == '64bit'
 
 if ARCH == 'ppc64le':


### PR DESCRIPTION
Running within a generic docker container (`python:3.7`) on M1, I was having build issues.

Try to install via pip or via setup.py directly would fail on linking to the libampl.so, since the architecture was inferred incorrectly, i.e.
```
/usr/bin/ld: skipping incompatible amplpy/amplpython/cppinterface/lib/amd64/libampl.so when searching for -lampl
/usr/bin/ld: cannot find -lampl
```

Following the "clone and setup.py" method failed because it uses platform.processor() which is an empty string on M1 within Docker. However, platform.machine() works.
![image](https://user-images.githubusercontent.com/353887/170459750-f19fbcbd-c2f4-49fd-a287-ecd12685b1f9.png)


This PR just adds platform.machine() as a backup for the cases where platform.processor() is an empty string when determining the `ARCH` variable. This enabled the setup to find correct .so and enabled me to install the package.

I also changed the link for the git clone. Accessing via git@github.com seems to need elevated access and fails for me, while git clone of https always works.
